### PR TITLE
Set time to midnight for yesterday aliases

### DIFF
--- a/src/worklogs/worklogs.ts
+++ b/src/worklogs/worklogs.ts
@@ -11,6 +11,7 @@ import aliases from '../config/aliases'
 
 const DATE_FORMAT = 'yyyy-MM-dd'
 const START_TIME_FORMAT = 'HH:mm:ss'
+const YESTERDAY_LITERALS = ['y', 'yesterday']
 
 export type AddWorklogInput = {
     issueKeyOrAlias: string
@@ -121,7 +122,11 @@ async function checkToken() {
 
 function parseWhenArg(now: Date, when: string | undefined): Date {
     if (when === undefined) return now
-    if (when === 'y' || when === 'yesterday') return addDays(now, -1)
+    if (YESTERDAY_LITERALS.includes(when)) {
+        const nowAtMidnight = new Date(now)
+        nowAtMidnight.setHours(0, 0, 0, 0)
+        return addDays(nowAtMidnight, -1)
+    }
     const date = fnsParse(when, DATE_FORMAT, new Date())
     if (isValid(date)) {
         return date

--- a/test/addWorklog.spec.ts
+++ b/test/addWorklog.spec.ts
@@ -159,6 +159,36 @@ describe('adds a worklog', () => {
                 startTime: '11:00:00'
             })
         })
+
+        test('2h at yesterday with "y" alias', async () => {
+            await worklogs.addWorklog({
+                issueKeyOrAlias: 'ABC-123',
+                durationOrInterval: '2h',
+                when: 'y'
+            })
+
+            expect(addWorklogMock).toHaveBeenCalledWith({
+                issueKey: 'ABC-123',
+                timeSpentSeconds: 7200,
+                startDate: '2020-02-27',
+                startTime: '00:00:00'
+            })
+        })
+
+        test('2h at yesterday with "yesterday" alias', async () => {
+            await worklogs.addWorklog({
+                issueKeyOrAlias: 'ABC-123',
+                durationOrInterval: '2h',
+                when: 'yesterday'
+            })
+
+            expect(addWorklogMock).toHaveBeenCalledWith({
+                issueKey: 'ABC-123',
+                timeSpentSeconds: 7200,
+                startDate: '2020-02-27',
+                startTime: '00:00:00'
+            })
+        })
     })
 
     test('with description', async () => {


### PR DESCRIPTION
Fixes an issue where logging with `y` and `yesterday` aliases used today's time instead of midnight when no time was provided.