### PR TITLE
Add remaining-estimate param, add some tests, refactor

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -9,7 +9,8 @@ export type AddWorklogRequest = {
     timeSpentSeconds: number;
     startDate: string;
     startTime: string;
-    description: string | undefined;
+    description?: string;
+    remainingEstimateSeconds?: number
 }
 
 export type GetWorklogsRequest = {

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -30,7 +30,8 @@ export default class Log extends Command {
       help: flags.help({ char: 'h' }),
       debug: flags.boolean(),
       description: flags.string({ char: 'd', description: 'worklog description' }),
-      start: flags.string({ char: 's', description: 'start time (HH:mm format), used when the input is a duration' })
+      start: flags.string({ char: 's', description: 'start time (HH:mm format), used when the input is a duration' }),
+      'remaining-estimate': flags.string({ char: 'r', description: 'remaining estimate' })
   }
 
   static args = [
@@ -61,7 +62,8 @@ export default class Log extends Command {
           durationOrInterval: args.duration_or_interval,
           when: args.when,
           description: flags.description,
-          startTime: flags.start
+          startTime: flags.start,
+          remainingEstimate: flags['remaining-estimate']
       })
   }
 }

--- a/src/commands/tracker/stop.ts
+++ b/src/commands/tracker/stop.ts
@@ -18,7 +18,8 @@ export default class Stop extends Command {
     static flags = {
         help: flags.help({ char: 'h' }),
         debug: flags.boolean(),
-        description: flags.string({ char: 'd', description: 'description for worklog' })
+        description: flags.string({ char: 'd', description: 'description for worklog' }),
+        'remaining-estimate': flags.string({ char: 'r', description: 'remaining estimate' })
     }
 
     static args = [
@@ -35,6 +36,7 @@ export default class Stop extends Command {
         tempo.stopTracker({
             issueKeyOrAlias: args.issue_key_or_alias,
             description: flags.description,
+            remainingEstimate: flags['remaining-estimate'],
             now: time.now()
         })
     }

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -136,7 +136,7 @@ export default {
                 return
             }
 
-            const intervalsWithInputs = createWorklogInputs(tracker)
+            const intervalsWithInputs = createWorklogInputs(tracker, input.remainingEstimate)
             if (intervalsWithInputs.length === 0) {
                 console.log('There are no intervals with minmal length of 0 minutes.')
                 await trackers.deleteTracker({ issueKeyOrAlias: tracker.issueKey })
@@ -212,7 +212,7 @@ async function deleteWorklog(worklogIdInput: string): Promise<void> {
     )
 }
 
-function createWorklogInputs(tracker: Tracker): [Interval, AddWorklogInput][] {
+function createWorklogInputs(tracker: Tracker, remainingEstimate?: string): [Interval, AddWorklogInput][] {
     return tracker.intervals.map(interval => {
         return [
             interval,
@@ -221,7 +221,8 @@ function createWorklogInputs(tracker: Tracker): [Interval, AddWorklogInput][] {
                 description: tracker.description,
                 when: fnsLightFormat(interval.start, 'yyyy-MM-dd'),
                 startTime: fnsLightFormat(interval.start, 'HH:mm'),
-                durationOrInterval: `${differenceInMinutes(interval.end, interval.start)}m`
+                durationOrInterval: `${differenceInMinutes(interval.end, interval.start)}m`,
+                remainingEstimate: remainingEstimate
             }
         ]
     })

--- a/src/trackers/trackers.ts
+++ b/src/trackers/trackers.ts
@@ -21,6 +21,7 @@ export type PauseTrackerInput = {
 export type StopTrackerInput = {
     issueKeyOrAlias: string,
     description?: string,
+    remainingEstimate?: string,
     now: Date
 }
 

--- a/test/addWorklog.spec.ts
+++ b/test/addWorklog.spec.ts
@@ -9,6 +9,8 @@ import aliases from '../src/config/aliases'
 
 jest.mock('../src/config/configStore', () => jest.requireActual('./mocks/configStore'))
 
+afterEach(() => { jest.clearAllMocks() })
+
 authenticator.saveCredentials({
     accountId: 'fakeAccountId',
     tempoToken: 'fakeToken'
@@ -100,6 +102,36 @@ describe('adds a worklog', () => {
                 startTime: '00:00:00'
             })
         })
+
+        test('2h at yesterday with "y" alias', async () => {
+            await worklogs.addWorklog({
+                issueKeyOrAlias: 'ABC-123',
+                durationOrInterval: '2h',
+                when: 'y'
+            })
+
+            expect(addWorklogMock).toHaveBeenCalledWith({
+                issueKey: 'ABC-123',
+                timeSpentSeconds: 7200,
+                startDate: '2020-02-27',
+                startTime: '00:00:00'
+            })
+        })
+
+        test('2h at yesterday with "yesterday" alias', async () => {
+            await worklogs.addWorklog({
+                issueKeyOrAlias: 'ABC-123',
+                durationOrInterval: '2h',
+                when: 'yesterday'
+            })
+
+            expect(addWorklogMock).toHaveBeenCalledWith({
+                issueKey: 'ABC-123',
+                timeSpentSeconds: 7200,
+                startDate: '2020-02-27',
+                startTime: '00:00:00'
+            })
+        })
     })
 
     describe('by interval', () => {
@@ -163,33 +195,17 @@ describe('adds a worklog', () => {
             })
         })
 
-        test('2h at yesterday with "y" alias', async () => {
+        test('12-12 (24h)', async () => {
             await worklogs.addWorklog({
                 issueKeyOrAlias: 'ABC-123',
-                durationOrInterval: '2h',
-                when: 'y'
+                durationOrInterval: '12-12'
             })
 
             expect(addWorklogMock).toHaveBeenCalledWith({
                 issueKey: 'ABC-123',
-                timeSpentSeconds: 7200,
-                startDate: '2020-02-27',
-                startTime: '00:00:00'
-            })
-        })
-
-        test('2h at yesterday with "yesterday" alias', async () => {
-            await worklogs.addWorklog({
-                issueKeyOrAlias: 'ABC-123',
-                durationOrInterval: '2h',
-                when: 'yesterday'
-            })
-
-            expect(addWorklogMock).toHaveBeenCalledWith({
-                issueKey: 'ABC-123',
-                timeSpentSeconds: 7200,
-                startDate: '2020-02-27',
-                startTime: '00:00:00'
+                timeSpentSeconds: 86400,
+                startDate: '2020-02-28',
+                startTime: '12:00:00'
             })
         })
     })
@@ -226,5 +242,106 @@ describe('adds a worklog', () => {
             startTime: '12:00:00',
             description: 'foo bar'
         })
+    })
+
+    test('with remaining estimate', async () => {
+        await worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '1h',
+            remainingEstimate: '2h'
+        })
+
+        expect(addWorklogMock).toHaveBeenCalledWith({
+            issueKey: 'ABC-123',
+            timeSpentSeconds: 3600,
+            startDate: '2020-02-28',
+            startTime: '12:00:00',
+            remainingEstimateSeconds: 7200
+        })
+    })
+
+    test('with 0h remaining estimate', async () => {
+        await worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '1h',
+            remainingEstimate: '0h'
+        })
+
+        expect(addWorklogMock).toHaveBeenCalledWith({
+            issueKey: 'ABC-123',
+            timeSpentSeconds: 3600,
+            startDate: '2020-02-28',
+            startTime: '12:00:00',
+            remainingEstimateSeconds: 0
+        })
+    })
+})
+
+describe('fails when', () => {
+    test('remaining estimate is negative', async () => {
+        await expect(worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '1h',
+            remainingEstimate: '-1h'
+        })).rejects.toEqual(
+            new Error('Error parsing "-1h". Try something like 1h. See tempo log --help for more examples.')
+        )
+    })
+
+    test('remaining estimate is invalid', async () => {
+        await expect(worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '1h',
+            remainingEstimate: 'something'
+        })).rejects.toEqual(
+            new Error('Error parsing "something". Try something like 1h. See tempo log --help for more examples.')
+        )
+    })
+
+    test('cannot parse date', async () => {
+        await expect(worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '1h',
+            when: 'whatever'
+        })).rejects.toEqual(
+            new Error('Cannot parse "whatever" to valid date. Try to use YYYY-MM-DD format. See tempo --help for more examples.')
+        )
+    })
+
+    test('cannot parse start time', async () => {
+        await expect(worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '1h',
+            startTime: 'foo'
+        })).rejects.toEqual(
+            new Error('Cannot parse foo to valid start time. Try to use HH:mm format. See tempo --help for more examples.')
+        )
+    })
+
+    test('duration or interval is invalid', async () => {
+        await expect(worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: 'something'
+        })).rejects.toEqual(
+            new Error('Error parsing "something". Try something like 1h10m or 11-12:30. See tempo log --help for more examples.')
+        )
+    })
+
+    test('duration is 0m', async () => {
+        await expect(worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '0m'
+        })).rejects.toEqual(
+            new Error('Error. Minutes worked must be larger than 0.')
+        )
+    })
+
+    test('duration is 0h', async () => {
+        await expect(worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '0h'
+        })).rejects.toEqual(
+            new Error('Error. Minutes worked must be larger than 0.')
+        )
     })
 })

--- a/test/deleteWorklog.spec.ts
+++ b/test/deleteWorklog.spec.ts
@@ -4,6 +4,8 @@ import authenticator from '../src/config/authenticator'
 
 jest.mock('../src/config/configStore', () => jest.requireActual('./mocks/configStore'))
 
+afterEach(() => { jest.clearAllMocks() })
+
 authenticator.saveCredentials({
     accountId: 'fakeAccountId',
     tempoToken: 'fakeToken'
@@ -45,4 +47,10 @@ test('deletes a worklog', async () => {
         issueKey: 'ABC-123',
         link: 'https://example.atlassian.net/browse/ABC-123'
     })
+})
+
+test('fails when worklog id is not an integer', async () => {
+    await expect(worklogs.deleteWorklog('something')).rejects.toEqual(
+        new Error('Error. Worklog id should be an integer number.')
+    )
 })

--- a/test/getUserWorklogs.spec.ts
+++ b/test/getUserWorklogs.spec.ts
@@ -8,6 +8,8 @@ import authenticator from '../src/config/authenticator'
 
 jest.mock('../src/config/configStore', () => jest.requireActual('./mocks/configStore'))
 
+afterEach(() => { jest.clearAllMocks() })
+
 authenticator.saveCredentials({
     accountId: 'fakeAccountId',
     tempoToken: 'fakeToken'

--- a/test/worklogsCommon.spec.ts
+++ b/test/worklogsCommon.spec.ts
@@ -1,0 +1,27 @@
+import worklogs from '../src/worklogs/worklogs'
+jest.mock('../src/config/configStore', () => jest.requireActual('./mocks/configStore'))
+
+afterEach(() => { jest.clearAllMocks() })
+
+describe('fails when tempo token is not set', () => {
+    test('when adding worklog', async () => {
+        await expect(worklogs.addWorklog({
+            issueKeyOrAlias: 'ABC-123',
+            durationOrInterval: '1h'
+        })).rejects.toEqual(
+            new Error('Tempo token not set. Setup tempomat by `tempo setup` command.')
+        )
+    })
+
+    test('when deleting worklog', async () => {
+        await expect(worklogs.deleteWorklog('123')).rejects.toEqual(
+            new Error('Tempo token not set. Setup tempomat by `tempo setup` command.')
+        )
+    })
+
+    test('when getting worklog', async () => {
+        await expect(worklogs.getUserWorklogs()).rejects.toEqual(
+            new Error('Tempo token not set. Setup tempomat by `tempo setup` command.')
+        )
+    })
+})


### PR DESCRIPTION
@MiSikora How should we implement this option in case of trackers? Maybe just add `--remaining-estimate` to `stop` command?   

Related to #30