### PR TITLE
Add empty "attributes" array to POST /worklogs request

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -60,7 +60,7 @@ export default {
 
     async addWorklog(request: AddWorklogRequest): Promise<WorklogEntity> {
         const credentials = await authenticator.getCredentials()
-        const body = { ...request, authorAccountId: credentials.accountId }
+        const body = { ...request, authorAccountId: credentials.accountId, attributes: [] }
         return execute(async () => {
             const response = await tempoAxios.post('/worklogs', body)
             debugLog(response)


### PR DESCRIPTION
Noticed a bug, that from 02.11.2020 tempo.io API requires "attributes" value for all POST /worklogs requests, despite this value isn't marked as required in the API documentation. Sending empty array is a workaround, until sending real worklog attributes is implemented in CLI.